### PR TITLE
Production bug — fixed in the repo

### DIFF
--- a/public/layout/footer.php
+++ b/public/layout/footer.php
@@ -131,7 +131,7 @@
     }
   })();
 </script>
-<?php asset_script($appBase, 'js/public.js'); ?>
+<?php asset_script($appBase, 'public/js/public.js'); ?>
 <?php if (!empty($pageScript)): ?>
 <!-- Page controller: pages are thin HTML shells; js/pages/public/<name>.js renders
      the dynamic sections through window.PublicSite. Falls back to SSR-only output


### PR DESCRIPTION
- Root cause: public/layout/footer.php:134 loaded js/public.js — a path that doesn't exist anywhere. Apache rewrote the miss to an HTML page (hence SyntaxError: got '<'), and ?v=0 was your asset versioner's filemtime() failing on the nonexistent file.
- The real file is public/js/public.js (tracked, 22 KB) — it renders the site-wide announcement ticker (#site-ticker) and nav scroll state. The footer just pointed at the wrong directory.
- Fix applied: footer now loads public/js/public.js. php -l passes.